### PR TITLE
Add opencode install subcommand

### DIFF
--- a/cmd/aka/main.go
+++ b/cmd/aka/main.go
@@ -26,6 +26,7 @@ func main() {
 		dockerCmd(),
 		kubectlCmd(),
 		ghCmd(),
+		opencodeCmd(),
 	)
 
 	cmd.SilenceUsage = true

--- a/cmd/aka/opencode.go
+++ b/cmd/aka/opencode.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	cmdpkg "github.com/pigfall/aka/pkg/cmd"
+	"github.com/spf13/cobra"
+)
+
+func opencodeCmd() *cobra.Command {
+	c := &cobra.Command{
+		Use: "opencode",
+	}
+
+	install := cmdpkg.InstallOpenCodeCmd{}
+	installCmd := &cobra.Command{
+		Use:  "install",
+		RunE: install.Run,
+	}
+	installCmd.Flags().StringVar(
+		&install.Version,
+		"version",
+		"",
+		"version to install (default: latest bundled version)",
+	)
+
+	c.AddCommand(
+		installCmd,
+	)
+
+	return c
+}

--- a/pkg/cmd/cmd_opencode.go
+++ b/pkg/cmd/cmd_opencode.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const defaultOpenCodeVersion = "1.4.3"
+
+type InstallOpenCodeCmd struct {
+	Version string
+}
+
+func (c *InstallOpenCodeCmd) Run(cmd *cobra.Command, args []string) error {
+	return installOpenCode(c.Version)
+}
+
+func installOpenCode(version string) error {
+	if version == "" {
+		version = defaultOpenCodeVersion
+	}
+
+	userHomePath, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+
+	dstPath := filepath.Join(userHomePath, "tools", "opencode")
+	os.RemoveAll(dstPath)
+	os.MkdirAll(dstPath, os.ModePerm)
+
+	platform := fmt.Sprintf("%s-%s", runtime.GOOS, runtime.GOARCH)
+	archiveName := opencodeArchiveName(platform)
+	if archiveName == "" {
+		return fmt.Errorf("unsupported platform: %s", platform)
+	}
+
+	downloadURL := fmt.Sprintf(
+		"https://github.com/anomalyco/opencode/releases/download/v%s/%s",
+		version,
+		archiveName,
+	)
+	downloadPath := filepath.Join(os.TempDir(), archiveName)
+	os.Remove(downloadPath)
+
+	if err := downloadToFile(downloadURL, downloadPath); err != nil {
+		return fmt.Errorf("download from %s error: %w", downloadURL, err)
+	}
+
+	if strings.HasSuffix(archiveName, ".tar.gz") {
+		uncompressCmd := exec.Command("tar", "-xf", downloadPath, "-C", dstPath)
+		uncompressCmd.Stdout = os.Stdout
+		uncompressCmd.Stderr = os.Stderr
+		if err := uncompressCmd.Run(); err != nil {
+			return fmt.Errorf("uncompress %s error: %w", downloadPath, err)
+		}
+	} else {
+		uncompressCmd := exec.Command("unzip", "-o", downloadPath, "-d", dstPath)
+		uncompressCmd.Stdout = os.Stdout
+		uncompressCmd.Stderr = os.Stderr
+		if err := uncompressCmd.Run(); err != nil {
+			return fmt.Errorf("uncompress %s error: %w", downloadPath, err)
+		}
+	}
+
+	binaryPath := filepath.Join(dstPath, "opencode")
+	if runtime.GOOS == "windows" {
+		binaryPath = filepath.Join(dstPath, "opencode.exe")
+	}
+	if _, err := os.Stat(binaryPath); err != nil {
+		return fmt.Errorf("opencode binary not found at %s", binaryPath)
+	}
+	if runtime.GOOS != "windows" {
+		if err := os.Chmod(binaryPath, 0755); err != nil {
+			return fmt.Errorf("chmod %s error: %w", binaryPath, err)
+		}
+	}
+
+	binDir := dstPath
+	shrc := []string{
+		".bashrc",
+		".zshrc",
+	}
+	for _, v := range shrc {
+		v = filepath.Join(userHomePath, v)
+		if _, err := os.Stat(v); err == nil {
+			f, err := os.OpenFile(v, os.O_RDWR|os.O_APPEND|os.O_CREATE, os.ModePerm)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			if _, err := f.WriteString(fmt.Sprintf("\nexport PATH=$PATH:%s", binDir)); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func opencodeArchiveName(platform string) (archiveName string) {
+	switch platform {
+	case "darwin-arm64":
+		archiveName = "opencode-darwin-arm64.zip"
+	case "darwin-amd64":
+		archiveName = "opencode-darwin-x64.zip"
+	case "linux-arm64":
+		archiveName = "opencode-linux-arm64.tar.gz"
+	case "linux-amd64":
+		archiveName = "opencode-linux-x64.tar.gz"
+	case "windows-arm64":
+		archiveName = "opencode-windows-arm64.zip"
+	case "windows-amd64":
+		archiveName = "opencode-windows-x64.zip"
+	default:
+		return ""
+	}
+
+	return archiveName
+}


### PR DESCRIPTION
## Summary
- add a new `aka opencode install` subcommand and wire it into the root CLI
- implement `InstallOpenCodeCmd` with a `--version` override and a default version fallback
- download and extract platform-specific OpenCode release archives into `$HOME/tools/opencode` and append that path to shell rc files